### PR TITLE
theme polish: drop unused inter font + add print stylesheet

### DIFF
--- a/themes/bryan-chasko-theme/assets/css/extended/print.css
+++ b/themes/bryan-chasko-theme/assets/css/extended/print.css
@@ -1,0 +1,100 @@
+/* print stylesheet — strip everything decorative, optimize for ink + paper
+   prospects who print services pages or save notes as pdf get a clean read */
+
+@media print {
+	/* canvas + decorative chrome */
+	.constellation-hero,
+	.webgl-container,
+	canvas {
+		display: none !important;
+	}
+
+	/* nav, header chrome, footer, social icons, theme toggle */
+	header,
+	nav,
+	footer,
+	.top-link,
+	#theme-toggle,
+	.social-icons,
+	.share-icons,
+	.post-nav-links,
+	.theme-toc {
+		display: none !important;
+	}
+
+	/* page surface — black on white, no gradients */
+	html,
+	body,
+	main {
+		background: #ffffff !important;
+		color: #000000 !important;
+	}
+
+	/* prose width — full page minus standard print margins */
+	.main,
+	.theme-page,
+	article {
+		max-width: 100% !important;
+		margin: 0 !important;
+		padding: 0 !important;
+		background: transparent !important;
+		box-shadow: none !important;
+	}
+
+	/* links — show urls inline so paper readers can navigate */
+	a {
+		color: #000000 !important;
+		text-decoration: underline;
+	}
+
+	a[href^="http"]::after {
+		content: " (" attr(href) ")";
+		font-size: 0.85em;
+		color: #555555;
+	}
+
+	/* skip url annotation on internal anchors + non-text links */
+	a[href^="#"]::after,
+	a[href^="mailto:"]::after {
+		content: "";
+	}
+
+	/* pagination hygiene */
+	h1,
+	h2,
+	h3,
+	h4 {
+		page-break-after: avoid;
+		color: #000000 !important;
+		background: transparent !important;
+		-webkit-text-fill-color: initial !important;
+	}
+
+	pre,
+	blockquote,
+	.theme-card-specimen,
+	.swatch,
+	.font-stack,
+	.spacing-row,
+	.shadow-row {
+		page-break-inside: avoid;
+	}
+
+	/* code blocks — keep readable, drop chroma colors */
+	pre,
+	code {
+		background: #f4f4f4 !important;
+		color: #000000 !important;
+		border: 1px solid #cccccc !important;
+	}
+
+	/* drop card decoration */
+	.theme-card-specimen,
+	.help-service-card,
+	.builder-note-card {
+		border: 1px solid #cccccc !important;
+		background: transparent !important;
+		box-shadow: none !important;
+		backdrop-filter: none !important;
+	}
+}

--- a/themes/bryan-chasko-theme/layouts/partials/head.html
+++ b/themes/bryan-chasko-theme/layouts/partials/head.html
@@ -1,9 +1,8 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+{{- /* fonts: system stack only — see --font-body in css/core/variables.css.
+       no web-font fetch, no third-party preconnect, no foit/fout */}}
 {{- if hugo.IsProduction | or (eq site.Params.env "production") | and (ne .Params.robotsNoIndex true) }}
 <meta name="robots" content="index, follow">
 {{- else }}


### PR DESCRIPTION
## Summary
- drop unused Inter Google Font preload — site uses system stack per variables.css, third-party request is dead weight
- add @media print stylesheet — clean black-on-white render for prospects who print services pages or save notes as pdf

## Test plan
- [ ] CI green (biome + markdownlint)
- [ ] hugo build clean
- [ ] no inter font request in network tab on next page load
- [ ] print preview (cmd+p) on a services page renders cleanly without canvas/nav/footer

originating agent: hs-shannon-theseus-orin-github-ops