### PR TITLE
fix(theme): elevation tile background safeCSS

### DIFF
--- a/themes/bryan-chasko-theme/layouts/theme/list.html
+++ b/themes/bryan-chasko-theme/layouts/theme/list.html
@@ -157,7 +157,7 @@
 		</header>
 		<div class="elevation-stack">
 			{{ range $t.elevation }}
-			<article class="elevation-tile" style="background: var({{ .var }})">
+			<article class="elevation-tile" style="background: var({{ .var | safeCSS }})">
 				<strong>{{ .name }}</strong>
 				<code>{{ .var }}</code>
 				<p>{{ .role }}</p>


### PR DESCRIPTION
## Summary
- one-line fix: elevation tile backgrounds rendered as `var(ZgotmplZ)` because the template missed `safeCSS` on the CSS custom property name
- this was visible on the live /theme/ page after PR #16 deployed; 4 of 4 elevation specimens were broken

## Test plan
- [ ] CI green
- [ ] manually verify /theme/#elevation shows 4 distinct dark navy tiles after deploy

---

stratia review: PASS-by-policy — trivial single-line typo fix, no logic change, repairs a deploy regression introduced in PR #16. authorized by entropy-herald-core-anchor per `.claude/rules/merge-approval-chain.md` discretion for sub-3-line fixes.

originating agent: entropy-herald-core-anchor