### PR TITLE
home: replace inline emoji-string with structured links array

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -77,7 +77,35 @@ summaryLength = 50
 
 [params.homeInfoParams]
   Title = "Hello, Friend ^.^"
-Content = "[🦊&nbsp;About](notes/posts/about-bryan-chasko) [🐈&nbsp;Buddy](notes/posts/my-cat-buddy) [🏈&nbsp;#ForeverNE](notes/posts/new-england-patriots-fandom) [🔧&nbsp;Skills](notes/posts/my-skills-and-experience#skills) [📈&nbsp;Experience](notes/posts/my-skills-and-experience#experience) [☁️&nbsp;AWS Cloud](notes/posts/aws-hero-bryan-chasko) [📅&nbsp;Booking](services)"
+
+  [[params.homeInfoParams.links]]
+    emoji = "🦊"
+    label = "About"
+    url = "notes/posts/about-bryan-chasko"
+  [[params.homeInfoParams.links]]
+    emoji = "🐈"
+    label = "Buddy"
+    url = "notes/posts/my-cat-buddy"
+  [[params.homeInfoParams.links]]
+    emoji = "🏈"
+    label = "#ForeverNE"
+    url = "notes/posts/new-england-patriots-fandom"
+  [[params.homeInfoParams.links]]
+    emoji = "🔧"
+    label = "Skills"
+    url = "notes/posts/my-skills-and-experience#skills"
+  [[params.homeInfoParams.links]]
+    emoji = "📈"
+    label = "Experience"
+    url = "notes/posts/my-skills-and-experience#experience"
+  [[params.homeInfoParams.links]]
+    emoji = "☁️"
+    label = "AWS Cloud"
+    url = "notes/posts/aws-hero-bryan-chasko"
+  [[params.homeInfoParams.links]]
+    emoji = "📅"
+    label = "Booking"
+    url = "services"
 
   [[params.homeInfoParams.instagram]]
     url = "https://www.instagram.com/p/EXAMPLE1/"

--- a/themes/bryan-chasko-theme/layouts/partials/home_info.html
+++ b/themes/bryan-chasko-theme/layouts/partials/home_info.html
@@ -2,7 +2,7 @@
 
 <article class="first-entry home-info">
     <div class="entry-content">
-        {{ .Content | markdownify }}
+        {{ partial "home_info_links.html" . }}
     </div>
     <footer class="entry-footer">
         {{/* Social icons - moved inside entry-footer */}}

--- a/themes/bryan-chasko-theme/layouts/partials/home_info_links.html
+++ b/themes/bryan-chasko-theme/layouts/partials/home_info_links.html
@@ -1,0 +1,10 @@
+{{/* render homeInfoParams.links as a horizontal nav of emoji + label markdown links
+     source: hugo.toml `[[params.homeInfoParams.links]]` array of tables
+     replaces a fragile single-line markdown blob with structured config */}}
+{{- with site.Params.homeInfoParams.links }}
+<p class="home-info-links">
+{{- range $i, $link := . }}{{ if $i }} {{ end -}}
+<a href="{{ $link.url | relURL }}">{{ $link.emoji }}&nbsp;{{ $link.label }}</a>
+{{- end }}
+</p>
+{{- end }}


### PR DESCRIPTION
## Summary
- replace fragile single-line markdown string in `hugo.toml` `[params.homeInfoParams].Content` with structured `[[params.homeInfoParams.links]]` array-of-tables (emoji/label/url per entry)
- add `layouts/partials/home_info_links.html` to render the array
- adding/removing/reordering homepage shortcuts is now a 4-line TOML edit instead of an emoji-laden string surgery

## Visual change
None expected — same 7 links, same emoji, same urls, same render

## Out of scope (next sprint backlog)
While reading `home_info.html` I noticed two stale references not addressed in this PR:
- lines 62-67: workflow status badges point at `.github/workflows/deploy.yml` + `webgl-tests.yml` — github actions retired 2026-04-13, badges are 404
- lines 51, 208, 235: repo references use legacy `BryanChasko/hugoBryanChaskoWebsite` — the live repo is `chasko-labs/bryan-chasko-com`

Both are user-visible bugs on the homepage (broken badges, wrong "Website Code" link). Recommend filing as separate issues + addressing in a follow-up sprint

## Test plan
- [ ] CI green
- [ ] hugo build clean
- [ ] homepage renders the 7 links unchanged

originating agent: hs-shannon-theseus-orin-github-ops