### PR TITLE
fix #22: homepage badges — repoint urls + onerror fallback

### DIFF
--- a/themes/bryan-chasko-theme/layouts/partials/home_info.html
+++ b/themes/bryan-chasko-theme/layouts/partials/home_info.html
@@ -48,7 +48,7 @@
                         </svg>
                         <span>@bryanChasko</span>
                     </a>
-                    <a href="https://github.com/BryanChasko/hugoBryanChaskoWebsite" target="_blank" rel="noopener noreferrer" class="github-dashboard__button github-repo-button">
+                    <a href="https://github.com/chasko-labs/bryan-chasko-com" target="_blank" rel="noopener noreferrer" class="github-dashboard__button github-repo-button">
                         <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
                             <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/>
                         </svg>
@@ -56,14 +56,18 @@
                     </a>
                 </div>
 
-                {{/* Workflow Status Badges - Live CI/CD status */}}
+                {{/* Pipeline + repo status badges. Defensive onerror — if any badge cdn is unreachable
+                    we hide the parent rather than render a broken-image icon (regression guard for #22) */}}
                 <div class="github-dashboard-card">
                     <div class="github-workflow-badges">
-                        <a href="https://github.com/BryanChasko/hugoBryanChaskoWebsite/actions/workflows/deploy.yml" target="_blank" rel="noopener noreferrer" class="github-workflow-badge">
-                            <img src="https://github.com/BryanChasko/hugoBryanChaskoWebsite/actions/workflows/deploy.yml/badge.svg?branch=main" alt="Build & Deploy to S3" loading="lazy" />
+                        <a href="https://github.com/chasko-labs/bryan-chasko-com/commits/main" target="_blank" rel="noopener noreferrer" class="github-workflow-badge">
+                            <img src="https://img.shields.io/github/last-commit/chasko-labs/bryan-chasko-com/main?style=flat-square&label=last%20commit&color=5e41a2" alt="Last commit on main" loading="lazy" onerror="this.parentElement.style.display='none'" />
                         </a>
-                        <a href="https://github.com/BryanChasko/hugoBryanChaskoWebsite/actions/workflows/webgl-tests.yml" target="_blank" rel="noopener noreferrer" class="github-workflow-badge">
-                            <img src="https://github.com/BryanChasko/hugoBryanChaskoWebsite/actions/workflows/webgl-tests.yml/badge.svg?branch=main" alt="WebGL Visual Regression & Performance Tests" loading="lazy" />
+                        <a href="https://github.com/chasko-labs/bryan-chasko-com/actions" target="_blank" rel="noopener noreferrer" class="github-workflow-badge">
+                            <img src="https://img.shields.io/badge/ci-woodpecker-FF9900?style=flat-square&logo=woodpeckerci&logoColor=white" alt="CI: woodpecker" loading="lazy" onerror="this.parentElement.style.display='none'" />
+                        </a>
+                        <a href="https://github.com/chasko-labs/bryan-chasko-com" target="_blank" rel="noopener noreferrer" class="github-workflow-badge">
+                            <img src="https://img.shields.io/badge/hosted-aws%20s3%20%2B%20cloudfront-5e41a2?style=flat-square&logo=amazonaws&logoColor=white" alt="Hosted on AWS S3 + CloudFront" loading="lazy" onerror="this.parentElement.style.display='none'" />
                         </a>
                     </div>
                 </div>
@@ -205,7 +209,7 @@
                     }
 
                     try {
-                        const response = await fetch('https://api.github.com/repos/BryanChasko/hugoBryanChaskoWebsite/commits?per_page=1');
+                        const response = await fetch('https://api.github.com/repos/chasko-labs/bryan-chasko-com/commits?per_page=1');
                         if (!response.ok) throw new Error(`HTTP ${response.status}`);
                         
                         const data = await response.json();
@@ -232,7 +236,7 @@
                     }
 
                     try {
-                        const response = await fetch('https://api.github.com/repos/BryanChasko/hugoBryanChaskoWebsite/languages');
+                        const response = await fetch('https://api.github.com/repos/chasko-labs/bryan-chasko-com/languages');
                         if (!response.ok) throw new Error(`HTTP ${response.status}`);
                         
                         const data = await response.json();


### PR DESCRIPTION
## Summary
- closes #22
- replace 2 broken github-actions badges (retired workflow paths, 404 every page load, render as broken-image icons) with 3 shields.io badges that work: last-commit · ci-woodpecker · hosted-aws-s3-cloudfront
- swap all 8 `BryanChasko/hugoBryanChaskoWebsite` references to `chasko-labs/bryan-chasko-com` — fixes link destinations + github API fetches for latest-commit + tech-stack panels
- defensive: every badge `<img>` gets `onerror="this.parentElement.style.display='none'"` so future cdn outages hide cleanly instead of showing broken icons

## Why both
- connection fixes resolve the immediate visible bug (broken icons on every page load)
- onerror guard prevents the same class of regression — if shields.io ever 404s a single badge, parent hides; never a broken-image icon again

## Test plan
- [ ] CI green
- [ ] / homepage renders 3 working badges in the github dashboard card
- [ ] / latest-commit + tech-stack panels populate from chasko-labs/bryan-chasko-com (not the legacy repo)
- [ ] artificial test: pointing a badge img to a 404 url and reloading hides the parent (no broken icon visible)

originating agent: entropy-herald-core-anchor