### PR TITLE
fix(style): strip emoji + add ascii header (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
-# Bryan Chasko - Cloudcroft Cloud Company 🌿🌸
+# bryan chasko · cloudcroft cloud company
+
+```
++--------------------------------------------------+
+|  bryan chasko · cloudcroft cloud company         |
+|  bryanchasko.com                                 |
+|  aws · ai/ml · hugo · cloudfront · woodpecker   |
++--------------------------------------------------+
+```
 
 ---
 
-## 📄 Markdown Style Guide
+## markdown style guide
 
 See [MARKDOWN_GUIDE.md](MARKDOWN_GUIDE.md) for Markdown syntax, formatting, autoformatting, and linting instructions.
 
 ---
 
----
-
-## 🧑‍💻 Agentic Instructions
+## agentic instructions
 
 For focused agent instructions (CSS, setup, CI/CD, etc.), see [agentic_instructions/README.md](agentic_instructions/README.md) for the full menu and links to all fragments.
 
@@ -24,9 +30,9 @@ hugo --minify --gc
 
 Deploy: push to main — woodpecker pipeline at `.woodpecker/deploy.yml` builds with hugo, syncs to s3://bryanchasko.com, invalidates cloudfront E2E9BSL5RVN6DI. Auth via rolesanywhere → ci-deploy → ci-bryanchasko (no long-lived iam keys)
 
-## 🏗️ Architecture Diagrams
+## architecture diagrams
 
-### Website Architecture
+### website architecture
 
 ```mermaid
 %%{init: {'flowchart': {'curve': 'linear'}, 'theme': 'base', 'themeVariables': {'fontSize': '16px', 'fontFamily': 'arial', 'lineColor': '#d8bfd8'}}}%%
@@ -41,7 +47,7 @@ graph TB
     style C fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
     style D fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
     style F fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
-## 🚀 How to Replicate This Stack for Your Own Site
+## how to replicate this stack for your own site
 
   "SITE_DISTRIBUTION_ID": "E1ABC2DEF3GHIJ",
 ```
@@ -112,9 +118,9 @@ graph TB
 
     - Hugo reports missing config: confirm current working dir contains `hugo.toml` or pass `--config`/`--source`.
 
-    ## 🚀 Deployment & Best Practices
+    ## deployment & best practices
 
-    ### Deployment Workflow
+    ### deployment workflow
 
     **ALWAYS follow this workflow to prevent broken code in production:**
 
@@ -130,7 +136,7 @@ graph TB
 
     Auth chain: rolesanywhere trust anchor → ci-deploy → ci-bryanchasko (site-scoped). Zero long-lived iam keys.
 
-    ### Quick Deploy
+    ### quick deploy
 
     ```bash
     # ensure working on main and all tests pass
@@ -144,7 +150,7 @@ graph TB
     curl -I https://bryanchasko.com/
     ```
 
-    ## 🏗️ AWS Architecture
+    ## aws architecture
 
     This site uses a modern, secure AWS architecture:
 
@@ -162,17 +168,17 @@ graph TB
 
     See [**AWS_ARCHITECTURE.md**](AWS_ARCHITECTURE.md) for complete architecture documentation.
 
-    ## 🔐 Security & Secrets Management
+    ## security & secrets management
 
     **Never commit AWS credentials or account-specific data to GitHub.**
 
-    ### What's Gitignored (Account-Specific)
+    ### what's gitignored (account-specific)
     - `_README_HOSTING.md` - Deployment instructions
     - `_AWS_ENVIRONMENT_DETAILS.md` - Account details
     - `bucket-policy.json`, `cloudfront-config.json` - Infrastructure configs
     - All `*-config.json` files
 
-    ### Configuration
+    ### configuration
     Use `~/.bcc-site/config.json` for your AWS settings (not in GitHub):
 
     ```json
@@ -193,5 +199,5 @@ graph TB
     - Run the site locally to verify changes: `hugo server --config hugo.toml -D`.
     - **IMPORTANT**: Don't push to main without:
       /* Lines 717-745 omitted */
-    Thank you — happy hacking! 🎉
+    thank you — happy hacking
 ````

--- a/hugo.toml
+++ b/hugo.toml
@@ -79,31 +79,24 @@ summaryLength = 50
   Title = "Hello, Friend ^.^"
 
   [[params.homeInfoParams.links]]
-    emoji = "🦊"
     label = "About"
     url = "notes/posts/about-bryan-chasko"
   [[params.homeInfoParams.links]]
-    emoji = "🐈"
     label = "Buddy"
     url = "notes/posts/my-cat-buddy"
   [[params.homeInfoParams.links]]
-    emoji = "🏈"
     label = "#ForeverNE"
     url = "notes/posts/new-england-patriots-fandom"
   [[params.homeInfoParams.links]]
-    emoji = "🔧"
     label = "Skills"
     url = "notes/posts/my-skills-and-experience#skills"
   [[params.homeInfoParams.links]]
-    emoji = "📈"
     label = "Experience"
     url = "notes/posts/my-skills-and-experience#experience"
   [[params.homeInfoParams.links]]
-    emoji = "☁️"
     label = "AWS Cloud"
     url = "notes/posts/aws-hero-bryan-chasko"
   [[params.homeInfoParams.links]]
-    emoji = "📅"
     label = "Booking"
     url = "services"
 


### PR DESCRIPTION
## summary

closes #13 — strips 19 emoji violations, adds ascii art banner, collapses redundant hr separators per heraldstack writing style guide.

## scope

- \`README.md\` — title, 7 section headers, closing line cleaned of emoji; ascii banner added near top; redundant \`---\` blocks collapsed to single separators
- \`hugo.toml\` — 7 emoji decorators stripped from \`homeInfoParams.links\` array; labels were already meaningful one-word strings, no inference needed

## known limitation

voss flagged pre-existing structural corruption in README.md while editing:
- unclosed mermaid block at line ~37 (missing \`\`\` terminator before line 50)
- unclosed \`\`\`json fence from line ~55 to EOF at 203

these were out of scope for #13 (style-only audit). filed at follow-on issue #25 for structural repair.

## test plan

- [ ] hugo build succeeds (\`hugo --minify\`) without new errors beyond pre-existing structural ones
- [ ] visual confirm README.md renders on github with no emoji and ascii banner present
- [ ] homeInfoParams.links display on home page without emoji decorators

originating agent: entropy-herald-core-anchor