### PR TITLE
fix(theme): add emoji fallback chain to font stack + service-icon font-family

### DIFF
--- a/themes/bryan-chasko-theme/assets/css/components/cloudcroft.css
+++ b/themes/bryan-chasko-theme/assets/css/components/cloudcroft.css
@@ -203,6 +203,9 @@
 	display: inline-block;
 	filter: drop-shadow(0 2px 8px rgba(94, 65, 162, 0.2));
 	transition: transform var(--transition-base);
+	/* explicit emoji chain so glyph renders on Linux/Android without OS auto-cascade */
+	font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+		"Noto Color Emoji", sans-serif;
 }
 
 .ccc-service-card:hover .service-icon {
@@ -289,6 +292,9 @@
 	display: inline-block;
 	filter: drop-shadow(0 2px 8px rgba(94, 65, 162, 0.2));
 	transition: transform var(--transition-base);
+	/* explicit emoji chain so glyph renders on Linux/Android without OS auto-cascade */
+	font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+		"Noto Color Emoji", sans-serif;
 }
 
 .ccc-service-card:hover .service-icon {

--- a/themes/bryan-chasko-theme/assets/css/extended/nebula.css
+++ b/themes/bryan-chasko-theme/assets/css/extended/nebula.css
@@ -362,11 +362,13 @@
 	/* Typography */
 	--font-body:
 		-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-		Cantarell, sans-serif;
+		Cantarell, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+		"Segoe UI Symbol", "Noto Color Emoji";
 	--font-heading: var(--font-body);
 	--font-mono:
 		ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo,
-		monospace;
+		monospace, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+		"Noto Color Emoji";
 
 	--font-size-xs: 0.75rem; /* 12px */
 	--font-size-sm: 0.875rem; /* 14px */


### PR DESCRIPTION
## summary

closes #29. fixes broken emoji rendering across services cards and notes posts that previously rendered as empty squares on systems where the OS emoji font isn't auto-cascaded.

## scope

- `nebula.css` — appended canonical emoji fallback chain (Apple → Segoe → Noto) to `--font-body` and `--font-mono`
- `cloudcroft.css` — explicit font-family on `.service-icon`

## audit re-diagnosis vs original framing

original audit reported "4 of 5 service icons missing, only lightning bolt renders." liora's inspection found all 5 service cards use emoji glyphs uniformly (⚡ 🔒 🤖 🛡️ 🌱). the lightning bolt that appeared to "work" in screenshots was also an emoji — it just happened to render where the others failed because some emoji glyphs have wider OS coverage than others. root cause unified: missing emoji fallback in font stack.

## test plan

- [x] hugo --buildDrafts=false --quiet exits 0
- [ ] visual confirm services cards show all 5 emoji glyphs in both modes
- [ ] visual confirm about-bryan-chasko notes post list items render emoji glyphs correctly

originating agent: entropy-herald-core-anchor