### PR TITLE
feat(theme): aria-pressed sync, color transition, themechange event

### DIFF
--- a/themes/bryan-chasko-theme/assets/css/extended/nebula.css
+++ b/themes/bryan-chasko-theme/assets/css/extended/nebula.css
@@ -474,6 +474,16 @@
 	--code-bg: var(--gray-700);
 	--border: var(--color-border);
 }
+/* Theme transition — softens color/border swap on theme toggle (#30)
+   Scoped to color and border-color only; background radial-gradients hard-swap
+   (smooth gradient interpolation not feasible across full gradient sets).
+   Covered by the global prefers-reduced-motion: reduce block below (0.01ms). */
+*, *::before, *::after {
+	transition:
+		color var(--duration-base) var(--ease-out),
+		border-color var(--duration-base) var(--ease-out);
+}
+
 /* Typography Styles */
 
 body {

--- a/themes/bryan-chasko-theme/layouts/partials/footer.html
+++ b/themes/bryan-chasko-theme/layouts/partials/footer.html
@@ -83,7 +83,7 @@
 
 {{- if (not site.Params.disableThemeToggle) }}
 <script>
-    document.getElementById("theme-toggle").addEventListener("click", () => {
+    document.getElementById("theme-toggle").addEventListener("click", function (event) {
         const html = document.querySelector("html");
         if (html.dataset.theme === "dark") {
             html.dataset.theme = 'light';
@@ -92,6 +92,12 @@
             html.dataset.theme = 'dark';
             localStorage.setItem("pref-theme", 'dark');
         }
+        // Sync aria-pressed to actual theme state (#30)
+        event.currentTarget.setAttribute('aria-pressed', html.dataset.theme === 'dark' ? 'true' : 'false');
+        // Dispatch themechange for webgl scene recoloring (#30)
+        // Listener wired by hs-shannon-theseus-tarn-babylonjs-engine-adapter in SceneInitializer.js
+        // event detail: { theme: 'dark' | 'light' }
+        window.dispatchEvent(new CustomEvent('themechange', { detail: { theme: html.dataset.theme } }));
     })
 
 </script>

--- a/themes/bryan-chasko-theme/layouts/partials/header.html
+++ b/themes/bryan-chasko-theme/layouts/partials/header.html
@@ -115,3 +115,14 @@
         </ul>
     </nav>
 </header>
+{{- if (not site.Params.disableThemeToggle) }}
+<script>
+    // Sync aria-pressed on load so it reflects the restored theme before any click (#30)
+    (function () {
+        var btn = document.getElementById('theme-toggle');
+        if (!btn) return;
+        var theme = document.documentElement.dataset.theme || 'light';
+        btn.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+    })();
+</script>
+{{- end }}


### PR DESCRIPTION
## summary

closes #30. fixes the three theme-toggle issues — silent aria-pressed, hard color flash, and webgl unaware of theme change.

## scope

- `header.html` — inline IIFE syncs aria-pressed to current theme on script parse
- `footer.html` — click handler updates aria-pressed + dispatches `themechange` CustomEvent
- `nebula.css` — global `*` selector transitions color + border-color via #36 tokens

## webgl follow-up

`themechange` CustomEvent is now dispatched but no webgl scene subscribes. tarn-babylonjs-engine-adapter follow-up will wire `window.addEventListener('themechange', ...)` in `SceneInitializer.js` to recolor scenes on swap. event detail: `{ theme: 'dark' | 'light' }`.

## prefers-reduced-motion

existing global block at `nebula.css:1357-1367` nullifies the new transitions for that audience via `!important transition-duration: 0.01ms`.

## test plan

- [x] hugo build passes
- [ ] visual: theme toggle press shows softened color transition, no hard flash on text/borders
- [ ] a11y: screen reader announces "pressed" / "not pressed" correctly
- [ ] webgl follow-up tracked separately

originating agent: entropy-herald-core-anchor