### PR TITLE
feat(webgl): subscribe scenes to themechange event

### DIFF
--- a/themes/bryan-chasko-theme/assets/js/constellation.js
+++ b/themes/bryan-chasko-theme/assets/js/constellation.js
@@ -237,7 +237,9 @@ class ConstellationScene {
 	}
 
 	setupThemeListener() {
-		// Use MutationObserver to watch for theme changes
+		// MutationObserver: watch data-theme attribute for direct DOM toggles.
+		// Kept for backwards compatibility with any toggle path that does not dispatch
+		// the 'themechange' CustomEvent.
 		const observer = new MutationObserver((mutations) => {
 			mutations.forEach((mutation) => {
 				if (mutation.attributeName === "data-theme") {
@@ -250,6 +252,13 @@ class ConstellationScene {
 			attributes: true,
 			attributeFilter: ["data-theme"],
 		});
+
+		// themechange CustomEvent: dispatched by the theme-toggle click handler.
+		// Color swap is instant — no tween — so prefers-reduced-motion is satisfied.
+		this._themeChangeHandler = () => {
+			this.updateThemeColors();
+		};
+		window.addEventListener("themechange", this._themeChangeHandler);
 
 		// Initial color setup
 		this.updateThemeColors();
@@ -531,6 +540,11 @@ class ConstellationScene {
 
 		if (this.resizeObserver) {
 			this.resizeObserver.disconnect();
+		}
+
+		if (this._themeChangeHandler) {
+			window.removeEventListener("themechange", this._themeChangeHandler);
+			this._themeChangeHandler = null;
 		}
 
 		if (this.gl) {

--- a/themes/bryan-chasko-theme/assets/js/webgl-scenes/OrbitScene.js
+++ b/themes/bryan-chasko-theme/assets/js/webgl-scenes/OrbitScene.js
@@ -207,6 +207,17 @@ class OrbitScene extends BaseScene {
 	}
 
 	/**
+	 * Flush cached color state after a theme swap.
+	 * Orbit particle and ring colors are read via getThemeColor() live each render frame,
+	 * so they auto-resolve from the updated CSS vars without any flush here.
+	 * Only centerNode.color is stored at construction time and must be refreshed.
+	 * Called by SceneInitializer._themeChangeHandler on the 'themechange' CustomEvent.
+	 */
+	applyTheme(_theme) {
+		this.centerNode.color = this.getThemeColor("--cosmic-energy");
+	}
+
+	/**
 	 * Override destroy to cleanup container reference
 	 */
 	destroy() {

--- a/themes/bryan-chasko-theme/assets/js/webgl-scenes/SceneInitializer.js
+++ b/themes/bryan-chasko-theme/assets/js/webgl-scenes/SceneInitializer.js
@@ -41,6 +41,9 @@ class WebGLSceneInitializer {
 		// Setup navigation transitions
 		this.setupNavigationTransitions();
 
+		// Subscribe to theme-toggle CustomEvent
+		this.setupThemeChangeListener();
+
 		this.isInitialized = true;
 	}
 
@@ -261,6 +264,38 @@ class WebGLSceneInitializer {
 	}
 
 	/**
+	 * Subscribe to themechange CustomEvent fired by the theme-toggle handler.
+	 * All registered scenes that expose applyTheme() receive the new theme value.
+	 * Scenes that read CSS vars live each frame (RippleScene, ShimmerScene) pick up
+	 * the updated vars automatically — applyTheme() is only required for scenes that
+	 * cache color state at construction time (OrbitScene, SkillsNetworkScene).
+	 * Color swap is always instant — no tween — so prefers-reduced-motion is satisfied.
+	 */
+	setupThemeChangeListener() {
+		this._themeChangeHandler = (e) => {
+			const theme = e.detail?.theme;
+			if (!theme) return;
+
+			// Dispatch to all managed scenes
+			for (const scene of this.scenes) {
+				if (typeof scene.applyTheme === "function") {
+					scene.applyTheme(theme);
+				}
+			}
+
+			// Dispatch to transition scene (reads data-theme live, no-op but safe to call)
+			if (
+				this.transitionScene &&
+				typeof this.transitionScene.applyTheme === "function"
+			) {
+				this.transitionScene.applyTheme(theme);
+			}
+		};
+
+		window.addEventListener("themechange", this._themeChangeHandler);
+	}
+
+	/**
 	 * Cleanup all scenes
 	 */
 	dispose() {
@@ -275,6 +310,12 @@ class WebGLSceneInitializer {
 			this.transitionScene.destroy();
 		}
 		this.transitionScene = null;
+
+		// Unbind themechange listener
+		if (this._themeChangeHandler) {
+			window.removeEventListener("themechange", this._themeChangeHandler);
+			this._themeChangeHandler = null;
+		}
 
 		this.isInitialized = false;
 	}

--- a/themes/bryan-chasko-theme/assets/js/webgl-scenes/SkillsNetworkScene.js
+++ b/themes/bryan-chasko-theme/assets/js/webgl-scenes/SkillsNetworkScene.js
@@ -325,6 +325,24 @@ class SkillsNetworkScene extends BaseScene {
 		}
 	}
 
+	/**
+	 * Flush cached node color state after a theme swap.
+	 * Edge colors are read via getThemeColor() live each render frame and auto-resolve.
+	 * Node colors are stored per-node at initializeNetwork() time and must be refreshed.
+	 * Called by SceneInitializer._themeChangeHandler on the 'themechange' CustomEvent.
+	 */
+	applyTheme(_theme) {
+		for (const node of this.nodes) {
+			if (node.layer === 0) {
+				node.color = this.getThemeColor("--nebula-orange");
+			} else if (node.layer === 1) {
+				node.color = this.getThemeColor("--nebula-purple");
+			} else {
+				node.color = this.getThemeColor("--nebula-lavender");
+			}
+		}
+	}
+
 	setupFallback() {
 		// Create SVG fallback
 		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");


### PR DESCRIPTION
## summary

closes the webgl follow-up for #30. wires `window.addEventListener('themechange', ...)` into the scene system so scenes recolor on theme swap. event was dispatched by liora's PR #38; this PR is the consumer side.

## scope

4 js files under `assets/js/`:
- SceneInitializer.js — global listener + per-scene applyTheme dispatch
- OrbitScene.js, SkillsNetworkScene.js — applyTheme implementations
- constellation.js — listener alongside existing MutationObserver

## scenes by mode

| scene | mode |
|---|---|
| OrbitScene | applyTheme |
| SkillsNetworkScene | applyTheme |
| ShimmerScene, RippleScene, TransitionScene | css-var-live (no applyTheme needed) |
| ConstellationScene | own listener + MutationObserver fallback |

## test plan

- [x] hugo --buildDrafts=false --quiet exits 0
- [ ] toggle theme on / — webgl scenes recolor without reload
- [ ] toggle theme on /notes/posts/my-skills-and-experience/ — SkillsNetworkScene reflects palette change

originating agent: entropy-herald-core-anchor