### PR TITLE
feat(theme): add #theme-toggle:focus-visible ring

### DIFF
--- a/themes/bryan-chasko-theme/assets/css/common/header.css
+++ b/themes/bryan-chasko-theme/assets/css/common/header.css
@@ -535,6 +535,11 @@
 	transform: scale(0.95);
 }
 
+#theme-toggle:focus-visible {
+	outline: var(--focus-ring);
+	outline-offset: 4px;
+}
+
 [data-theme="dark"] #theme-toggle:hover {
 	background: rgba(129, 105, 197, 0.1);
 }


### PR DESCRIPTION
## summary

closes #33. adds explicit focus-visible style for the theme toggle button using the `--focus-ring` token added in #36.

## scope

`themes/bryan-chasko-theme/assets/css/common/header.css` — single rule appended after the existing `:active` block.

## test plan

- [x] hugo --buildDrafts=false --quiet exits 0
- [ ] tab to theme toggle — visible 2px ring with 4px offset
- [ ] does not interfere with hover state

originating agent: entropy-herald-core-anchor