### PR TITLE
feat(theme): fluid heading type scale via clamp()

### DIFF
--- a/themes/bryan-chasko-theme/assets/css/extended/nebula.css
+++ b/themes/bryan-chasko-theme/assets/css/extended/nebula.css
@@ -1157,23 +1157,28 @@ h6 {
 	margin-bottom: var(--space-md);
 }
 
+/* fluid type scale (#31) — 1.25 modular scale anchored at 1rem base,
+   min viewport 320px / max viewport 1280px. preferred vw derived from
+   (max-size - min-size) / (1280 - 320) * 100. prefers-reduced-motion guard
+   not needed here — clamp() is a size function, not an animation.
+   system-font stack preserved (no web font fetch, no foit) — see head.html:4-6. */
 h1 {
-	font-size: var(--font-size-4xl);
+	font-size: clamp(1.875rem, 2.29vw + 1.146rem, 2.5rem);
 }
 h2 {
-	font-size: var(--font-size-3xl);
+	font-size: clamp(1.5rem, 1.56vw + 1.0rem, 2rem);
 }
 h3 {
-	font-size: var(--font-size-2xl);
+	font-size: clamp(1.25rem, 0.78vw + 1.0rem, 1.5rem);
 }
 h4 {
-	font-size: var(--font-size-xl);
+	font-size: clamp(1.125rem, 0.39vw + 1.0rem, 1.25rem);
 }
 h5 {
-	font-size: var(--font-size-lg);
+	font-size: clamp(1rem, 0.39vw + 0.875rem, 1.125rem);
 }
 h6 {
-	font-size: var(--font-size-base);
+	font-size: clamp(0.875rem, 0.39vw + 0.75rem, 1rem);
 }
 
 p {
@@ -1342,16 +1347,7 @@ section {
 	:root {
 		--font-size-base: 1.0625rem; /* 17px */
 	}
-
-	h1 {
-		font-size: 2.5rem;
-	}
-	h2 {
-		font-size: 2rem;
-	}
-	h3 {
-		font-size: 1.75rem;
-	}
+	/* h1/h2/h3 fixed overrides removed — fluid clamp() in base rules covers this range (#31) */
 }
 
 /* Desktop: 1024px and up */


### PR DESCRIPTION
## summary

closes #31 (corrected scope). adds site-wide fluid type scale for h1-h6 via `clamp()`. removes the redundant breakpoint overrides for headings (clamp does the job).

## scope

`themes/bryan-chasko-theme/assets/css/extended/nebula.css`:
- h1-h6 font-size replaced with clamp() pairs across 320-1280px range, 1.25 modular scale
- 768px media query h1/h2/h3 overrides removed
- --font-size-base body bump retained

## what's intentionally NOT in this PR

display/heading face pairing is the second part of the corrected #31. system-font is preserved here per the no-FOIT constraint at head.html:4-6. a display-face proposal is a separate design decision for bryan and lands as a follow-up if pursued.

## test plan

- [x] hugo --buildDrafts=false --quiet exits 0
- [ ] visual: heading sizes scale smoothly between mobile + desktop, no breakpoint hops
- [ ] .home-info hero h1 narrower override still wins (intentionally preserved at line 1684)

originating agent: entropy-herald-core-anchor