### PR TITLE
feat(cards): featured first-card treatment for note-entry + help-service-card

### DIFF
--- a/themes/bryan-chasko-theme/assets/css/components/cards.css
+++ b/themes/bryan-chasko-theme/assets/css/components/cards.css
@@ -3,6 +3,21 @@
    .help-service-card + .note-entry demoted to flat — backdrop-filter +
    decorative pseudo-elements removed to drop mobile gpu cost (audit 2026-04-26) */
 
+/* Featured (first) service card — parallel lead treatment to .note-entry:first-of-type (#32)
+   border-left accent + heading size bump. stagger animation-delay unaffected. */
+.help-service-card:first-of-type {
+	border-left: 3px solid var(--brand-orange);
+	padding-left: calc(var(--space-lg) - 3px); /* compensate for border-left */
+}
+
+.help-service-card:first-of-type h3 {
+	font-size: clamp(1.3rem, 2.25vw, 1.6rem);
+}
+
+[data-theme="dark"] .help-service-card:first-of-type {
+	border-left-color: var(--brand-orange);
+}
+
 /* Service Cards - Flat Gradient */
 .help-services-list {
 	display: flex;
@@ -213,6 +228,23 @@
 #help-hero b {
 	color: var(--color-text);
 	line-height: var(--line-height-relaxed);
+}
+
+/* Featured (first) note-entry — lead card treatment (#32)
+   border-left accent + heading size bump. no layout reshape.
+   parallels .help-service-card:first-of-type below. */
+.note-entry:first-of-type {
+	border-left: 3px solid var(--brand-orange);
+	padding-left: calc(40px - 3px); /* compensate for border-left so text stays flush */
+}
+
+.note-entry:first-of-type .entry-header h2,
+.note-entry:first-of-type .entry-hint-parent {
+	font-size: clamp(1.55rem, 3vw, 1.9rem);
+}
+
+[data-theme="dark"] .note-entry:first-of-type {
+	border-left-color: var(--brand-orange);
 }
 
 /* Blog Post Cards - Professional Tech Brand Design */


### PR DESCRIPTION
## summary

closes #32. featured-card treatment for the lead .note-entry on home and lead .help-service-card on services. minimal-touch CSS only.

## scope

`themes/bryan-chasko-theme/assets/css/components/cards.css`:
- `.note-entry:first-of-type` — border-left 3px var(--brand-orange) + heading clamp(1.55rem, 3vw, 1.9rem)
- `.help-service-card:first-of-type` — same border-left accent + h3 clamp(1.3rem, 2.25vw, 1.6rem)

both with explicit dark-mode selectors. padding compensated to keep text baselines flush with sibling cards.

## interaction with prior PRs

- card hover lift (#36) preserved
- entrance-stagger animation (#34) preserved — :first-of-type animation-delay stays 0ms; featured treatment is border + font only
- fluid type scale (#43) preserved — featured headings use clamp() consistent with the new scale

## test plan

- [x] hugo build exits 0
- [ ] visual: first home note-entry stands out vs subsequent cards
- [ ] visual: first services card has lead treatment
- [ ] both modes verified

originating agent: entropy-herald-core-anchor