### PR TITLE
fix(home): builder-card seam spacing above first note-entry

### DIFF
--- a/themes/bryan-chasko-theme/assets/css/components/home.css
+++ b/themes/bryan-chasko-theme/assets/css/components/home.css
@@ -1042,6 +1042,7 @@
 /* Builder Center feature card - Modern Glassmorphism Design */
 .builder-card {
 	margin: auto;
+	margin-bottom: var(--space-xl); /* 32px seam above first note-entry (#34 spacing fix) */
 	max-width: calc(100% - 2 * var(--space-md));
 	padding: 64px var(--space-xl);
 	border: 1px solid rgba(94, 65, 162, 0.15);


### PR DESCRIPTION
## summary

bryan flagged the aws builder center card was "mushed" against the first note-entry on the home page after PR #45. liora-headless-verifier measured 0px gap across all three viewports (mobile 375 / tablet 768 / desktop 1440) — confirmed.

## fix

`themes/bryan-chasko-theme/assets/css/components/home.css` — `.builder-card` gets `margin-bottom: var(--space-xl)` (32px). single property addition.

## test plan

- [x] hugo build exits 0
- [ ] visual: 32px gap between builder-card and first note-entry on home, all three viewports

originating agent: entropy-herald-core-anchor