### PR TITLE
fix(constellation): block star reaction when cursor is over interactive content

### DIFF
--- a/themes/bryan-chasko-theme/assets/js/constellation.js
+++ b/themes/bryan-chasko-theme/assets/js/constellation.js
@@ -286,6 +286,18 @@ class ConstellationScene {
 	}
 
 	onMouseMove(e) {
+		// Block star reaction when cursor is over interactive content areas.
+		// Canvas sits at z-index: -2 so mousemove fires on document regardless of
+		// what element is visually under the pointer — this guard restores idle
+		// behavior (stars drift as if mouse were off-screen) when over those elements.
+		const blocked = e.target.closest(
+			"article.note-entry, .builder-card, nav, .home-social-container, a, button, .help-service-card, footer",
+		);
+		if (blocked) {
+			this.mousePos.x = -1000;
+			this.mousePos.y = -1000;
+			return;
+		}
 		const rect = this.canvas.getBoundingClientRect();
 		const dpr = Math.min(window.devicePixelRatio || 1, 2);
 		this.mousePos.x = (e.clientX - rect.left) * dpr;
@@ -294,6 +306,15 @@ class ConstellationScene {
 
 	onTouchMove(e) {
 		if (e.touches.length > 0) {
+			// Same guard as onMouseMove — block star reaction over interactive content.
+			const blocked = e.touches[0].target?.closest(
+				"article.note-entry, .builder-card, nav, .home-social-container, a, button, .help-service-card, footer",
+			);
+			if (blocked) {
+				this.mousePos.x = -1000;
+				this.mousePos.y = -1000;
+				return;
+			}
 			const rect = this.canvas.getBoundingClientRect();
 			const dpr = Math.min(window.devicePixelRatio || 1, 2);
 			this.mousePos.x = (e.touches[0].clientX - rect.left) * dpr;


### PR DESCRIPTION
## summary

bryan reported the constellation stars move when the cursor hovers over the "How I Became an AWS Hero" note-entry, the cards below it, and the top nav — should only react over true background areas. liora-headless-verifier source-confirmed the bug at constellation.js:74 (`document.addEventListener('mousemove', ...)` with no target check).

## fix

`themes/bryan-chasko-theme/assets/js/constellation.js`:
- `onMouseMove(e)` — `e.target.closest('article.note-entry, .builder-card, nav, .home-social-container, a, button, .help-service-card, footer')` early return + mousePos reset
- `onTouchMove(e)` — same guard via `e.touches[0].target?.closest(...)` (optional chaining for synthetic touch events)

## why this approach

the canvas sits at z-index: -2 (behind content). the dev comment in constellation.js intentionally routed mousemove through `document` so the canvas could receive interaction. this fix preserves that pattern but gates on event.target so cursor over interactive content suppresses star reaction.

zero render-loop cost — guard fires in event handler only.

## test plan

- [x] hugo build exits 0
- [ ] manual: stars react over body whitespace, do NOT react over cards / nav / footer

originating agent: entropy-herald-core-anchor