### PR TITLE
fix(nav): revert hamburger + remove 3 home-info links

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -90,16 +90,6 @@ summaryLength = 50
   [[params.homeInfoParams.links]]
     label = "Skills"
     url = "notes/posts/my-skills-and-experience#skills"
-  [[params.homeInfoParams.links]]
-    label = "Experience"
-    url = "notes/posts/my-skills-and-experience#experience"
-  [[params.homeInfoParams.links]]
-    label = "AWS Cloud"
-    url = "notes/posts/aws-hero-bryan-chasko"
-  [[params.homeInfoParams.links]]
-    label = "Booking"
-    url = "services"
-
   [[params.homeInfoParams.instagram]]
     url = "https://www.instagram.com/p/EXAMPLE1/"
     image = "/images/insta/example1.jpg"

--- a/themes/bryan-chasko-theme/assets/css/common/header.css
+++ b/themes/bryan-chasko-theme/assets/css/common/header.css
@@ -181,6 +181,34 @@
 		justify-content: center !important;
 	}
 
+	#menu {
+		display: flex !important;
+		flex-direction: row !important;
+		flex-wrap: nowrap !important;
+		gap: 2px !important;
+		flex: 1 1 auto !important;
+		justify-content: flex-end !important;
+		align-items: center !important;
+		margin: 0 !important;
+		overflow-x: auto !important;
+		overflow-y: hidden !important;
+		min-width: 0 !important;
+	}
+
+	#menu li {
+		display: inline-flex !important;
+		flex-shrink: 1 !important;
+		min-width: 0 !important;
+		list-style: none !important;
+	}
+
+	#menu li a {
+		padding: 0.2em 0.4em !important;
+		font-size: clamp(0.55rem, 2.5vw, 0.75rem) !important;
+		white-space: nowrap !important;
+		display: inline-block !important;
+	}
+
 	/* Hide span text and replace with CCC abbreviation */
 	#menu li a[href*="cloudcroft"] span {
 		display: none;
@@ -850,112 +878,4 @@
 		0 4px 20px rgba(255, 153, 0, 0.25),
 		0 0 30px -8px rgba(255, 153, 0, 0.35),
 		inset 0 1px 0 rgba(255, 153, 0, 0.15);
-}
-
-/* ── hamburger toggle — mobile nav ───────────────── */
-
-/* hidden on desktop */
-.nav-hamburger {
-	display: none;
-}
-
-@media (max-width: 768px) {
-	/* show hamburger, hide desktop menu */
-	.nav-hamburger {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		align-items: center;
-		gap: 5px;
-		padding: 8px;
-		background: transparent;
-		border: 1px solid rgba(94, 65, 162, 0.20);
-		border-radius: var(--radius-md);
-		cursor: pointer;
-		flex-shrink: 0;
-		order: 2; /* right of logo, left of nothing */
-		transition: background var(--transition-fast), border-color var(--transition-fast);
-	}
-
-	[data-theme="dark"] .nav-hamburger {
-		border-color: rgba(129, 105, 197, 0.25);
-	}
-
-	.nav-hamburger:hover {
-		background: rgba(94, 65, 162, 0.08);
-		border-color: rgba(94, 65, 162, 0.35);
-	}
-
-	[data-theme="dark"] .nav-hamburger:hover {
-		background: rgba(129, 105, 197, 0.10);
-		border-color: rgba(129, 105, 197, 0.40);
-	}
-
-	.nav-hamburger:focus-visible {
-		outline: var(--focus-ring);
-		outline-offset: 3px;
-	}
-
-	.nav-hamburger-bar {
-		display: block;
-		width: 20px;
-		height: 2px;
-		background: var(--nebula-lavender);
-		border-radius: 2px;
-	}
-
-	[data-theme="dark"] .nav-hamburger-bar {
-		background: var(--nebula-lavender);
-	}
-
-	/* menu hidden by default on mobile */
-	#menu {
-		display: none !important;
-		position: absolute !important;
-		top: 100% !important;
-		left: 0 !important;
-		right: 0 !important;
-		flex-direction: column !important;
-		align-items: stretch !important;
-		padding: var(--space-sm) var(--space-md) !important;
-		background: rgba(255, 255, 255, 0.96) !important;
-		backdrop-filter: blur(20px) !important;
-		-webkit-backdrop-filter: blur(20px) !important;
-		border-bottom: 1px solid rgba(94, 65, 162, 0.15) !important;
-		box-shadow: 0 8px 24px rgba(94, 65, 162, 0.10) !important;
-		gap: var(--space-xs) !important;
-		z-index: 999 !important;
-		overflow-x: visible !important;
-		overflow-y: visible !important;
-	}
-
-	[data-theme="dark"] #menu {
-		background: rgba(28, 34, 48, 0.97) !important;
-		border-bottom-color: rgba(129, 105, 197, 0.20) !important;
-		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.30) !important;
-	}
-
-	/* open state toggled by JS */
-	#menu.nav-open {
-		display: flex !important;
-	}
-
-	#menu li {
-		display: block !important;
-		width: 100% !important;
-	}
-
-	#menu li a {
-		display: block !important;
-		width: 100% !important;
-		padding: var(--space-sm) var(--space-md) !important;
-		font-size: var(--font-size-sm) !important;
-		white-space: normal !important;
-		border-radius: var(--radius-md) !important;
-	}
-
-	/* header must be relative for absolute menu positioning */
-	.header {
-		position: relative !important;
-	}
 }

--- a/themes/bryan-chasko-theme/layouts/partials/header.html
+++ b/themes/bryan-chasko-theme/layouts/partials/header.html
@@ -83,18 +83,6 @@
                 {{- end }}
             </div>
         </div>
-        <button
-            class="nav-hamburger"
-            id="nav-hamburger"
-            aria-label="open navigation menu"
-            aria-expanded="false"
-            aria-controls="menu"
-            type="button"
-        >
-            <span class="nav-hamburger-bar"></span>
-            <span class="nav-hamburger-bar"></span>
-            <span class="nav-hamburger-bar"></span>
-        </button>
         {{- $currentPage := . }}
         <ul id="menu">
             {{- range site.Menus.main }}
@@ -138,32 +126,3 @@
     })();
 </script>
 {{- end }}
-<script>
-    // mobile nav hamburger toggle
-    (function () {
-        var hamburger = document.getElementById('nav-hamburger');
-        var menu = document.getElementById('menu');
-        if (!hamburger || !menu) return;
-        hamburger.addEventListener('click', function () {
-            var isOpen = menu.classList.toggle('nav-open');
-            hamburger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-            hamburger.setAttribute('aria-label', isOpen ? 'close navigation menu' : 'open navigation menu');
-        });
-        // close on outside click
-        document.addEventListener('click', function (e) {
-            if (!hamburger.contains(e.target) && !menu.contains(e.target)) {
-                menu.classList.remove('nav-open');
-                hamburger.setAttribute('aria-expanded', 'false');
-                hamburger.setAttribute('aria-label', 'open navigation menu');
-            }
-        });
-        // close on nav link click (SPA-style navigation)
-        menu.addEventListener('click', function (e) {
-            if (e.target.closest('a')) {
-                menu.classList.remove('nav-open');
-                hamburger.setAttribute('aria-expanded', 'false');
-                hamburger.setAttribute('aria-label', 'open navigation menu');
-            }
-        });
-    })();
-</script>


### PR DESCRIPTION
## summary

bryan reported "3 links stuck under header" — which i misinterpreted in PR #48 as the main nav menu and "fixed" with a hamburger toggle. wrong target. the actual links were 3 home-info button entries in `hugo.toml` introduced this week.

this PR:
1. fully reverts the hamburger nav from PR #48 (header.html + header.css restored to pre-#48 state)
2. removes the 3 home-info link entries: Experience, AWS Cloud, Booking

remaining home-info links: About, Buddy, #ForeverNE, Skills.

## what stays

design system prototypes at `/notes/posts/design-system-prototypes/` from PR #48 is not part of this revert — that post is unchanged.

## test plan

- [x] hugo --buildDrafts=false --quiet exits 0
- [ ] mobile (375): main nav back to pre-#48 row-scroll layout, hamburger gone
- [ ] desktop (1440): nav unchanged from current state
- [ ] home page renders 4 home-info link buttons (About, Buddy, #ForeverNE, Skills) — no Experience/AWS Cloud/Booking

originating agent: entropy-herald-core-anchor