### PR TITLE
feat(.deepagents): nova-pro coordinator + routing skill + nova-act crosslink

### DIFF
--- a/.deepagents/AGENTS.md
+++ b/.deepagents/AGENTS.md
@@ -1,0 +1,35 @@
+# Harald — bryanchasko.com Coordinator
+
+## Project
+Hugo portfolio site for Bryan Chasko. Theme: bryan-chasko-theme (PaperMod fork).
+Hosted via CloudFront + S3. Terraform in infrastructure/. Playwright visual regression tests.
+Repo: chasko-labs/bryan-chasko-com
+
+## Architecture
+- Hugo static site generator (hugo.toml)
+- Custom theme at themes/bryan-chasko-theme/
+- Playwright tests for WebGL and visual regression
+- Terraform for AWS infra (CloudFront, S3, ACM)
+- Woodpecker CI for deploy pipeline
+
+## Herald Roster
+- **voss** — Content, copy, blog posts, markdown authoring
+- **liora** — CSS, layout, theme templates, responsive design
+- **orin** — CI/CD, deploy, GitHub ops, Woodpecker pipeline
+- **stratia** — AWS infra, Terraform, CloudFront, S3 config
+
+## Delegation Rules
+- Content questions → voss
+- Visual/layout issues → liora
+- Deploy, CI, git ops → orin
+- Infrastructure, DNS, CDN → stratia
+- Ambiguous → ask before routing
+
+## Hard Rules
+- Hugo extended required for SCSS
+- All content in content/ as markdown
+- Tests must pass before deploy: `npm test`
+- Never edit public/ directly — it's generated
+- Coordinator runs on `bedrock_converse:us.amazon.nova-pro-v1:0` (us-west-2 via kiro account, IAM RolesAnywhere)
+- Heralds (voss/liora/orin/stratia) stay on Ollama qwen3:8b via heraldstack route()
+- See `.deepagents/skills/nova-routing/SKILL.md` for kill-switch and tier decision rules

--- a/.deepagents/config.toml
+++ b/.deepagents/config.toml
@@ -1,0 +1,42 @@
+[models]
+default = "bedrock_converse:us.amazon.nova-pro-v1:0"
+
+# Bedrock provider — coordinator tier (Harald only).
+# Auth: boto3 picks up credentials_profile_name from ~/.aws/config.
+# IAM RolesAnywhere chain handled transparently by boto3 — no extra keys here.
+# Heralds (voss/liora/orin/stratia) run on Ollama via heraldstack/orchestrator.py
+# create_harold_nova() — the per-tool LLM split is in code, not this config.
+
+[models.providers.bedrock_converse.params]
+region_name = "us-west-2"
+credentials_profile_name = "bryanchasko-kiro"
+
+[models.providers.bedrock_converse.profile."us.amazon.nova-pro-v1:0"]
+tool_calling = true
+max_input_tokens = 200000
+max_output_tokens = 5120
+
+[models.providers.bedrock_converse.profile."us.amazon.nova-lite-v1:0"]
+tool_calling = true
+max_input_tokens = 100000
+max_output_tokens = 5120
+
+# Ollama provider — herald-as-tool tier. Reachable from heraldstack code paths.
+[models.providers.ollama.profile."qwen3:8b"]
+tool_calling = true
+max_input_tokens = 32768
+max_output_tokens = 8192
+
+[models.providers.ollama.profile."llama3.1:8b"]
+tool_calling = true
+max_input_tokens = 16384
+max_output_tokens = 4096
+
+[models.providers.ollama.profile."llama3.2:3b"]
+tool_calling = true
+max_input_tokens = 128000
+max_output_tokens = 4096
+
+# TODO(sprint-3): swap coordinator default to trained voss-pro LoRA endpoint
+# once the May 14 primary plan sprint-3 retrain ships. Refs:
+# splintercells-deep-agents-cli/docs/nova-custom-planning/2026-05-14-primary-plan-summary.md

--- a/.deepagents/skills/nova-routing/SKILL.md
+++ b/.deepagents/skills/nova-routing/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: nova-routing
+description: Use this skill when deciding model selection for an agent invocation — kill-switch first, persona-tier second, complexity third
+---
+
+# Skill: Nova Routing
+
+## Decision tree
+
+Apply in order — first match wins:
+
+1. **Kill-switch**: read SSM parameter `/heraldstack/nova-custom/kill-switch` (us-west-2, kiro account 946179428633). If value is `on`, route to `ollama:qwen3:8b` regardless of tier. Cost-protection mode.
+2. **Never-train tier**: persona in {liora, orin, ralph-monitor, kade-vox, solan} → `ollama:qwen3:8b`. Per the May 14 primary plan, these never train and never invoke Bedrock.
+3. **Train-now tier**: persona in {voss-chasko-author, harald-anchor, tarn-mcp-forge} → `bedrock_converse:us.amazon.nova-pro-v1:0`. Pre-sprint-3, plain Nova Pro. Post-sprint-3, swap to trained LoRA endpoint per the planning doc.
+4. **Defer-tier (sprint 5+)**: persona in {stratia-variants, myrren-variants, ellow-variants, kerouac-source-scribe} → `bedrock_converse:us.amazon.nova-pro-v1:0` if `complexity_score >= 0.7` or `token_estimate > 4000`, else `ollama:qwen3:8b`.
+5. **Default**: `bedrock_converse:us.amazon.nova-pro-v1:0` — coordinator (Harald) class.
+
+## AWS auth
+
+Bedrock calls authenticate via IAM RolesAnywhere through the kiro account (946179428633, us-west-2). Credentials surface to boto3 via the `bryanchasko-kiro` profile in `~/.aws/config`. No long-lived IAM keys on disk. Cert lifecycle managed by `chasko-labs/secure-access`.
+
+## Origin
+
+Decision tree mirrors the `route()` function defined in `splintercells-deep-agents-cli/docs/nova-custom-planning/2026-05-14-primary-plan-summary.md`. That document is the origin spec — this skill is the live rule. If they diverge, this skill wins for runtime decisions; update both before merging.
+
+## Kill-switch flip
+
+Manual:
+
+```bash
+aws ssm put-parameter --name /heraldstack/nova-custom/kill-switch \
+  --value on --type String --overwrite \
+  --region us-west-2 --profile bryanchasko-kiro
+```
+
+Automated trigger: CloudWatch budget alarm at $280 training spend → SNS → Lambda → SSM put-parameter. Defined in `heraldstack-nova-custom` (private repo, not yet bootstrapped per May 14 plan sprint-0).

--- a/docs/nova-act-crosslink.md
+++ b/docs/nova-act-crosslink.md
@@ -1,0 +1,33 @@
+# splintercells nova-act — awareness note
+
+this site's playwright suite covers the orbit and constellation webgl scenes (`tests/webgl/orbit-scene.spec.js`, `tests/webgl/constellation-interaction.spec.js`), the menu-click cross-browser flow (`tests/menu-click.spec.js`), and webgl performance benchmarks (`tests/webgl/performance.spec.js`). ripple, skills-network, and transition scene specs are not yet authored. local playwright is the primary verification mechanism for visual regression on this repo, run via `npm test` or per-browser `npm run test:chromium|firefox|webkit`.
+
+the splintercells deepagents harness provides a complementary cloud-hosted tier: AWS Nova Act can exercise browser workflows from a remote host without requiring a local chromium instance. this is not a replacement.
+
+## entry point
+
+`invoke_nova_act_workflow` tool on the heraldstack-nova-mcp server at `http://rocm-aibox.local:8170/mcp` (or localhost:8170 from rocm-aibox).
+
+rate limit: 3 concurrent invocations, 30-minute timeout per slot (valkey semaphore).
+
+## when nova-act is appropriate for this repo
+
+- scheduled visual-regression checks that run without a local playwright session
+- verifying the bryanchasko.com cloudfront distribution (E2E9BSL5RVN6DI) from a remote host
+- multi-instance parallel webgl scene checks
+- ci runs that fire from microvms where chromium is not provisioned
+
+## when local playwright testing is correct
+
+- interactive sessions against the local hugo dev server (`hugo server --config hugo.toml`)
+- baseline image regeneration (`npm run test:update-baselines`)
+- anything requiring the egl/rocm gpu path for webgl surface verification
+- debugging a specific scene with `npm run test:debug` or `npm run test:headed`
+
+## implementation reference
+
+`BryanChasko/splintercells-deep-agents-cli` — see `docs/architecture.md` for tool signatures, aws auth, and rate limiter behavior.
+
+## aws account note
+
+nova-act runs in the kiro account (946179428633, us-east-1). this site deploys to a separate aws account via IAM RolesAnywhere → ci-deploy → ci-bryanchasko, with cloudfront distribution E2E9BSL5RVN6DI invalidated on each deploy. these are distinct accounts — nova-act invocations do not touch this site's S3 bucket (s3://bryanchasko.com) or cloudfront distribution unless explicitly wired.


### PR DESCRIPTION
Wires Bedrock Nova Pro as the deepagents coordinator default for
bryan-chasko-com (Harald-tier reasoning per May 14 primary plan). Heralds
(voss/liora/orin/stratia) remain on Ollama via heraldstack route() — the
deepagents config.toml default controls coordinator only; per-tool LLMs
live in heraldstack/orchestrator.py create_harold_nova().

Files:
- .deepagents/config.toml — default = bedrock_converse:us.amazon.nova-pro-v1:0,
  region us-west-2, credentials_profile_name bryanchasko-kiro. Nova-lite + Pro
  profiles declared with explicit max_input_tokens (100K/200K) and 5120
  max_output_tokens. Ollama profiles preserved as fallback tier. Sprint-3
  TODO inlined for the trained voss-pro LoRA endpoint swap.
- .deepagents/AGENTS.md — 3 lines added to Hard Rules pointing at the new
  routing skill. File stays under 50 lines per stratia-code-mapper guidance.
- .deepagents/skills/nova-routing/SKILL.md — new. 5-step decision tree
  mirroring the May 14 plan route() function. Kill-switch SSM parameter,
  RolesAnywhere auth chain, and CloudWatch budget alarm trigger documented.
- docs/nova-act-crosslink.md — new. Canonical splintercells crosslink doc
  pattern (matches cloud-del-norte and chrome-extension-moodle-uploader
  templates). Accurate playwright coverage claims (orbit + constellation +
  menu-click + performance — ripple/skills-network/transition specs not
  yet authored).

Auth: boto3 picks credentials_profile_name from ~/.aws/config; IAM
RolesAnywhere transparent. Kiro account 946179428633, us-west-2.

Reviewed by team critique (4-lens): architecture (stratia-code-mapper),
bedrock (stratia-bedrock-arch), nova (myrren-nova-inference),
style (scribe-style-enforcer). All BLOCKs resolved before authoring.